### PR TITLE
change jar names to jakarta.* for build

### DIFF
--- a/docker/build_javamailtck.sh
+++ b/docker/build_javamailtck.sh
@@ -34,8 +34,8 @@ fi
 if [ -z "$JAVAMAIL_BUNDLE_URL" ];then
   export JAVAMAIL_BUNDLE_URL=http://central.maven.org/maven2/com/sun/mail/javax.mail/1.6.1/javax.mail-1.6.1.jar
 fi
-wget $WGET_PROPS $JAF_BUNDLE_URL -O javax.activation.jar
-wget $WGET_PROPS $JAVAMAIL_BUNDLE_URL -O javax.mail.jar
+wget $WGET_PROPS $JAF_BUNDLE_URL -O jakarta.activation.jar
+wget $WGET_PROPS $JAVAMAIL_BUNDLE_URL -O jakarta.mail.jar
 
 which ant
 ant -version


### PR DESCRIPTION
The javax.activation.jar & javax.mail.jar were renamed to jakarta.activation.jar & jakarta.mail.jar just how it is referred in the build.xml.

Signed-off-by: alwin.joseph <alwin.joseph@oracle.com>