### PR TITLE
more changes of javax -> jakarta, updated the jar versions

### DIFF
--- a/QuickStart.txt
+++ b/QuickStart.txt
@@ -7,14 +7,14 @@ Running the TCK from the source
 1. Checkout TCK workspace in TCKHOME (e.g., "javamail-tck").
      git clone git@github.com:eclipse-ee4j/javamail-tck.git
    Change directory to $TCKHOME.
-2. Place javax.activation.jar (if using Java SE 9 or later)
-   and javax.mail.jar in any location. Let's call it JARPATH. 
+2. Place jakarta.activation.jar (if using Java SE 9 or later)
+   and jakarta.mail.jar in any location. Let's call it JARPATH. 
    It's usually simplest to just put them in $TCKHOME.
 3. Set CLASSPATH to
-     $TCKHOME/javatest.jar:$JARPATH/javax.activation.jar:$JARPATH/javax.mail.jar
+     $TCKHOME/javatest.jar:$JARPATH/jakarta.activation.jar:$JARPATH/jakarta.mail.jar
     
      on Windows:
-     %TCKHOME%\javatest.jar;%JARPATH%\javax.activation.jar;%JARPATH%\javax.mail.jar
+     %TCKHOME%\javatest.jar;%JARPATH%\jakarta.activation.jar;%JARPATH%\jakarta.mail.jar
 
 4. Set ANT_HOME to $TCKHOME/tools/ant.
 5. Add $ANT_HOME/bin to your path.

--- a/docker/build_javamailtck.sh
+++ b/docker/build_javamailtck.sh
@@ -29,10 +29,10 @@ mkdir -p ${HOME}/.m2
 cd $WORKSPACE
 WGET_PROPS="--progress=bar:force --no-cache"
 if [ -z "$JAF_BUNDLE_URL" ];then
-  export JAF_BUNDLE_URL=http://central.maven.org/maven2/com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar
+  export JAF_BUNDLE_URL=http://central.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar
 fi
 if [ -z "$JAVAMAIL_BUNDLE_URL" ];then
-  export JAVAMAIL_BUNDLE_URL=http://central.maven.org/maven2/com/sun/mail/javax.mail/1.6.1/javax.mail-1.6.1.jar
+  export JAVAMAIL_BUNDLE_URL=http://central.maven.org/maven2/com/sun/mail/jakarta.mail/1.6.3/jakarta.mail-1.6.3.jar
 fi
 wget $WGET_PROPS $JAF_BUNDLE_URL -O jakarta.activation.jar
 wget $WGET_PROPS $JAVAMAIL_BUNDLE_URL -O jakarta.mail.jar

--- a/docker/run_javamailtck.sh
+++ b/docker/run_javamailtck.sh
@@ -32,20 +32,19 @@ sed -i "s#^SMTP_FROM=.*#SMTP_FROM=user01@james.local#g" "$TS_HOME/lib/javamail.j
 sed -i "s#^SMTP_TO=.*#SMTP_TO=user01@james.local#g" "$TS_HOME/lib/javamail.jte"
 
 mkdir -p ${HOME}/.m2
-cp ${WORKSPACE}/docker/settings.xml ${HOME}/.m2
 
 WGET_PROPS="--progress=bar:force --no-cache"
 if [ -z "$JAF_BUNDLE_URL" ];then
-  export JAF_BUNDLE_URL=http://central.maven.org/maven2/com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar
+  export JAF_BUNDLE_URL=http://central.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar
 fi
 if [ -z "$JAVAMAIL_BUNDLE_URL" ];then
-  export JAVAMAIL_BUNDLE_URL=http://central.maven.org/maven2/com/sun/mail/javax.mail/1.6.1/javax.mail-1.6.1.jar
+  export JAVAMAIL_BUNDLE_URL=http://central.maven.org/maven2/com/sun/mail/jakarta.mail/1.6.3/jakarta.mail-1.6.3.jar
 fi
-wget $WGET_PROPS $JAF_BUNDLE_URL -O javax.activation.jar
-wget $WGET_PROPS $JAVAMAIL_BUNDLE_URL -O javax.mail.jar
+wget $WGET_PROPS $JAF_BUNDLE_URL -O jakarta.activation.jar
+wget $WGET_PROPS $JAVAMAIL_BUNDLE_URL -O jakarta.mail.jar
 
 cd $TS_HOME/tests/mailboxes
-export CLASSPATH=$TS_HOME/tests/mailboxes:$WORKSPACE/javax.mail.jar:$WORKSPACE/javax.activation.jar:$CLASSPATH
+export CLASSPATH=$TS_HOME/tests/mailboxes:$WORKSPACE/jakarta.mail.jar:$WORKSPACE/jakarta.activation.jar:$CLASSPATH
 javac -cp $CLASSPATH fpopulate.java
 java -cp $CLASSPATH fpopulate -s test1 -d imap://user01%40james.local:1234@localhost:1143
 

--- a/lib/javamail.jte
+++ b/lib/javamail.jte
@@ -27,13 +27,13 @@ TS_HOME=MUST-BE-SET
 JAVA_HOME=MUST-BE-SET
 
 # Set this to the directory containing the JavaMail .jar 
-# files (i.e., javax.mail.jar and javax.activation.jar)
+# files (i.e., jakarta.mail.jar and jakarta.activation.jar)
 JARPATH=.
 
 # Adjust these as necessary for Windows or UNIX
 
-##LOCAL_CLASSES=$JARPATH\\javax.mail.jar:$JARPATH\\javax.activation.jar
-LOCAL_CLASSES=$JARPATH/javax.mail.jar:$JARPATH/javax.activation.jar
+##LOCAL_CLASSES=$JARPATH\\jakarta.mail.jar:$JARPATH\\jakarta.activation.jar
+LOCAL_CLASSES=$JARPATH/jakarta.mail.jar:$JARPATH/jakarta.activation.jar
 
 ##TESTCLASS=$TS_HOME\\classes
 TESTCLASS=$TS_HOME/classes


### PR DESCRIPTION
Start using jakarta.activation.jar(1.2.1) & jakarta.mail.jar(1.6.3) versions to build and run the javamail-tck.

mail.jar - http://central.maven.org/maven2/com/sun/mail/jakarta.mail/1.6.3/jakarta.mail-1.6.3.jar
activation.jar - http://central.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar

Signed-off-by: alwin.joseph <alwin.joseph@oracle.com>